### PR TITLE
Rewrite README for discovery and onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,41 @@
-# Aethernet C++ client
+# Æthernet for Arduino and ESP32
 
-Please reffer to [aethernet.io](https://aethernet.io) for documentation.
+This library connects ESP32-based Arduino projects to Æthernet for secure real-time messaging, self-provisioning, and recovery on unstable networks.
 
-[Examples](https://github.com/aethernetio/aethernet-examples) of integrations into C++ and Java projects.
+[Documentation](https://aethernet.io/documentation) · [Tutorials](https://aethernet.io/tutorial) · [Examples](https://github.com/aethernetio/aethernet-examples)
 
-Install the Arduino IDE.
+## Supported environment
 
-![](doc/pics/pic1.jpg)
+- ESP32 boards;
+- Arduino IDE;
+- Wi-Fi connectivity.
 
-In the Board Manager, find and install the esp32 by Espressif Systems package.
+## Install from a ZIP file
 
-![](doc/pics/pic2.jpg)
+1. Download this repository using **Code → Download ZIP**.
+2. In Arduino IDE, choose **Sketch → Include Library → Add .ZIP Library**.
+3. Open **File → Examples → Aether** and select an example.
+4. Select your ESP32 board.
+5. Add your Wi-Fi SSID and password where the example indicates.
+6. Select a partition scheme with enough application space, such as **Minimal SPIFFS**, when required by your board configuration.
+7. Build, upload, and open the serial monitor.
 
-Download the library as a zip file from this repository.
+The screenshots in [`doc/pics`](doc/pics) show the same sequence in Arduino IDE.
 
-![](doc/pics/pic3.jpg)
+## What the examples demonstrate
 
-Install the library by selecting the menu item Sketch->Include Library->Add .ZIP Library...
+The included examples show device registration, connection to Æthernet, and message exchange. For multi-platform examples involving C++, Java, or TypeScript peers, use [aethernet-examples](https://github.com/aethernetio/aethernet-examples).
 
-![](doc/pics/pic4.jpg)
+## Current limitations
 
-If the installation is successful, you will see the message "Library installed"
-Load example by selecting the menu item File->Examples->Aether->[Example]
+- The library currently declares support for the `esp32` architecture.
+- Installation is currently ZIP-based; the project is not yet documented as an Arduino Library Manager package.
+- The compiled size depends on enabled logging, registration components, board core, and build configuration.
 
-![](doc/pics/pic5.jpg)
+## Issues
 
-Select your Board. For example ESP32 Wrover. And put your WiFi session ID and password.
+When reporting a problem, include the ESP32 board, Arduino core version, Arduino IDE version, partition scheme, and relevant serial output.
 
-![](doc/pics/pic6.jpg)
+## License
 
-Select the Partition Scheme Minimal SPIFFS. This example includes all logs and registration module with the binary footpring around 1.5 Mb
-
-![](doc/pics/pic7.jpg)
-
-Now you're ready to build, upload and run the example. The log contains all messages starting with "Hello, it's me".
+Apache License 2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Rewrites the README to improve GitHub discovery and make the repository easier to evaluate and use.

- states the repository purpose in the first screen
- adds verified requirements and build/install instructions
- links the relevant SDKs, examples, and documentation
- separates current capabilities from limitations
- avoids unverified performance claims

Draft for technical review before merging.